### PR TITLE
libcrypto_shim: Allow on system_ext

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -380,7 +380,8 @@ cc_library {
     srcs: [
         "libcrypto/cbs.c",
     ],
-    vendor: true
+    system_ext_specific: true,
+    vendor_available: true,
 }
 
 cc_library {


### PR DESCRIPTION
* For those with elfchecks, you're fine after this, for those without, you'll need to update makefiles to build libcrypto_shim.vendor.

* dopinder/wade have the following used libraries that need this:
```
grep: askey/wade/proprietary/system_ext/lib/libvendorfont.so: binary file matches
grep: askey/dopinder/proprietary/system_ext/lib/libvendorfont.so: binary file matches
```

Change-Id: Ia42de59ff157cddc930a111f8ce5e36e645055ed

Reviewed-on: https://review.blissroms.org/c/platform_hardware_lineage_compat/+/21699
Reviewed-by: Jack <jackeagle102@gmail.com>
Tested-by: Jack <jackeagle102@gmail.com>